### PR TITLE
Fix controller route attribute imports for Symfony 7

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,7 +1,6 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
-    annotations: false
     http_method_override: false
     handle_all_throwables: true
 

--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/games', name: 'game_')]
 final class GameController extends AbstractController

--- a/src/Controller/GameWebController.php
+++ b/src/Controller/GameWebController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 

--- a/src/Controller/MeController.php
+++ b/src/Controller/MeController.php
@@ -5,7 +5,7 @@ namespace App\Controller;
 use App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 final class MeController extends AbstractController
 {

--- a/src/Controller/TestAutoRefreshController.php
+++ b/src/Controller/TestAutoRefreshController.php
@@ -4,7 +4,7 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/test', name: 'test_')]
 final class TestAutoRefreshController extends AbstractController

--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -4,7 +4,7 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 final class UserProfileController extends AbstractController
 {

--- a/src/Controller/WerewolfController.php
+++ b/src/Controller/WerewolfController.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/games', name: 'werewolf_')]
 final class WerewolfController extends AbstractController


### PR DESCRIPTION
## Summary
- switch all controllers to import Symfony's Route attribute namespace
- drop the deprecated annotations toggle from the framework configuration

## Testing
- php bin/console cache:clear *(fails: missing vendor dependencies because composer install cannot satisfy symfony ^7 constraints with the current lock file)*
- ./vendor/bin/phpunit --testsuite functional *(fails: phpunit binary unavailable because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc77e91a48327a5a5c49424158eaf