### PR TITLE
Refactor create test users command to invokable signature

### DIFF
--- a/src/Command/CreateTestUsersCommand.php
+++ b/src/Command/CreateTestUsersCommand.php
@@ -8,8 +8,6 @@ use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -17,24 +15,17 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
     name: 'app:create-test-users',
     description: 'Creates dummy users for testing.',
 )]
-class CreateTestUsersCommand extends Command
+class CreateTestUsersCommand
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly CreateGameHandler $createGame,
     ) {
-        parent::__construct();
     }
 
-    protected function configure(): void
+    public function __invoke(SymfonyStyle $io): int
     {
-        // Pas d'argument count car on génère toujours 4 utilisateurs
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
         $count = 4; // Toujours 4 utilisateurs
 
         // Arrays pour générer des noms variés

--- a/tests/Unit/Command/CreateTestUsersCommandTest.php
+++ b/tests/Unit/Command/CreateTestUsersCommandTest.php
@@ -7,7 +7,10 @@ use App\Application\UseCase\CreateGameHandler;
 use App\Command\CreateTestUsersCommand;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 final class CreateTestUsersCommandTest extends TestCase
@@ -31,11 +34,13 @@ final class CreateTestUsersCommandTest extends TestCase
         $em->expects(self::once())->method('flush');
 
         $cmd = new CreateTestUsersCommand($em, $hasher, $handler);
-        $tester = new CommandTester($cmd);
-        $status = $tester->execute([]);
+        $output = new BufferedOutput();
+        $io = new SymfonyStyle(new ArrayInput([]), $output);
 
-        self::assertSame(0, $status);
-        $display = $tester->getDisplay();
+        $status = $cmd($io);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $output->fetch();
         self::assertStringContainsString('test users have been created', $display);
         self::assertStringContainsString('Games created for test users', $display);
     }


### PR DESCRIPTION
## Summary
- refactor the create test users command to use Symfony's invokable command signature with direct SymfonyStyle injection
- update the unit test to execute the command through the new invokable entry point

## Testing
- composer run cs:check
- composer run stan
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e00044acb483279054731f75b0be21