### PR TITLE
Enable precompressed asset builds

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -369,6 +369,32 @@ php bin/console asset-map:compile --env=prod
 
 Pour plus d'aide, consultez le [README.md](README.md) ou créez une [issue GitHub](https://github.com/magicolala/chess-teams/issues).
 
+### Service des assets précompressés
+
+Les commandes ci-dessus génèrent désormais des variantes Brotli (`.br`) et Gzip (`.gz`) pour les assets statiques (CSS, JS, JSON, SVG, Webmanifest, XML). Configurez votre serveur web pour servir ces fichiers précompressés lorsqu'un client annonce le support des encodages `br` ou `gzip`.
+
+Exemples:
+
+- **Nginx**
+
+    ```nginx
+    location /assets/ {
+        try_files $uri$br $uri$gzip $uri =404;
+        add_header Vary Accept-Encoding;
+    }
+    ```
+
+- **Apache (mod_negotiation)**
+
+    ```apache
+    <Location "/assets/">
+        Options +MultiViews
+        AddEncoding br .br
+        AddEncoding gzip .gz
+        Header append Vary Accept-Encoding
+    </Location>
+    ```
+
 ---
 
 Ressources complémentaires:

--- a/config/packages/asset_mapper.yaml
+++ b/config/packages/asset_mapper.yaml
@@ -4,6 +4,9 @@ framework:
         paths:
             - assets/
         missing_import_mode: strict
+        precompress:
+            formats: ['brotli', 'gzip']
+            extensions: ['css', 'js', 'json', 'svg', 'webmanifest', 'xml']
 
 when@prod:
     framework:


### PR DESCRIPTION
## Summary
- enable AssetMapper precompression for Brotli and Gzip on static assets
- document deployment guidance for serving the new precompressed variants

## Testing
- php bin/console asset-map:compile --env=prod
- composer run cs:check
- composer run stan
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e002a71f1c8327937cef0ddf5cf194