### PR TITLE
Centralize brand translations

### DIFF
--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -3,3 +3,6 @@ framework:
     translator:
         default_path: '%kernel.project_dir%/translations'
         providers:
+        globals:
+            app_name:
+                value: 'Chess Teams'

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="fr">
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<title>
-			{% block title %}Chess Teams
-			{% endblock %}
-		</title>
+<html lang="{{ app.request.locale }}">
+        <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>
+                        {% block title %}{{ 'layout.brand'|trans }}
+                        {% endblock %}
+                </title>
 
 		{{ importmap('app') }}
 
@@ -28,11 +28,11 @@
 			<header class="neo-header neo-mb-xl">
 				<div>
 					<h1 class="neo-header-title">
-						<a href="{{ path('app_home') }}" class="neo-text-primary" style="text-decoration: none;">
-							Chess Teams
-						</a>
-					</h1>
-					<span class="neo-header-info">Jeu d'échecs en équipe</span>
+                                                <a href="{{ path('app_home') }}" class="neo-text-primary" style="text-decoration: none;">
+                                                        {{ 'layout.brand'|trans }}
+                                                </a>
+                                        </h1>
+                                        <span class="neo-header-info">{{ 'layout.slogan'|trans }}</span>
 				</div>
 				
 				{# User info section #}
@@ -175,7 +175,7 @@
 				<script>
 					document.addEventListener('DOMContentLoaded', function () {
 						// NeoChess Framework JavaScript helpers
-						console.log('🎯 NeoChess Framework chargé - Chess Teams');
+                                                console.log('{{ 'layout.console_brand_loaded'|trans }}');
 						
 						// Gestion des messages flash flottants améliorée
 						const flashMessages = document.querySelectorAll('.neo-flash');

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -1,18 +1,18 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Accueil – Chess Teams
+{% block title %}{{ 'page.home.title'|trans }}
 {% endblock %}
 
 {% block body %}
 	<div class="neo-animate-fadeIn">
 		<!-- Hero Section -->
 		<div class="neo-text-center neo-mb-2xl">
-			<h2 class="neo-text-3xl neo-font-bold neo-text-primary neo-mb-md">
-				🏆 Chess Teams
-			</h2>
-			<p class="neo-text-lg neo-text-secondary neo-mb-xl">
-				Jouez aux échecs en équipe avec vos amis
-			</p>
+                        <h2 class="neo-text-3xl neo-font-bold neo-text-primary neo-mb-md">
+                                {{ 'page.home.hero_title'|trans }}
+                        </h2>
+                        <p class="neo-text-lg neo-text-secondary neo-mb-xl">
+                                {{ 'page.home.hero_tagline'|trans }}
+                        </p>
 		</div>
 
 

--- a/templates/registration/register.html.twig
+++ b/templates/registration/register.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Créer un compte - Chess Teams{% endblock %}
+{% block title %}{{ 'auth.register.title'|trans }}{% endblock %}
 
 
 {% block body %}
@@ -21,7 +21,7 @@
 					<div class="neo-card-header neo-text-center">
 						<div class="neo-text-4xl neo-mb-md">👥</div>
 						<h1 class="neo-card-title neo-text-xl">Créer un compte</h1>
-						<p class="neo-text-secondary">Rejoignez la communauté Chess Teams et jouez en équipe !</p>
+                                                <p class="neo-text-secondary">{{ 'auth.register.hero_tagline'|trans }}</p>
 					</div>
 					<div class="neo-card-content">
 						{{ form_start(registrationForm, {'attr': {'novalidate': 'novalidate'}}) }}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Connexion - Chess Teams
+{% block title %}{{ 'auth.login.title'|trans }}
 {% endblock %}
 
 {% block body %}

--- a/templates/user_profile/notifications.html.twig
+++ b/templates/user_profile/notifications.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Préférences de notifications - Chess Teams{% endblock %}
+{% block title %}{{ 'page.user_profile.notifications.title'|trans }}{% endblock %}
 
 {% block body %}
 <div class="neo-container neo-py-xl">

--- a/templates/user_profile/profile.html.twig
+++ b/templates/user_profile/profile.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Mon Profil - Chess Teams{% endblock %}
+{% block title %}{{ 'page.user_profile.profile.title'|trans }}{% endblock %}
 
 {% block body %}
 <div class="neo-container neo-py-xl">

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1,0 +1,22 @@
+layout:
+    brand: '%app_name%'
+    slogan: 'Team chess with your friends'
+    console_brand_loaded: '🎯 NeoChess Framework loaded - %app_name%'
+
+auth:
+    login:
+        title: 'Login - %app_name%'
+    register:
+        title: 'Create an account - %app_name%'
+        hero_tagline: 'Join the %app_name% community and play as a team!'
+
+page:
+    home:
+        title: 'Home – %app_name%'
+        hero_title: '🏆 %app_name%'
+        hero_tagline: 'Play team chess with your friends'
+    user_profile:
+        profile:
+            title: 'My Profile - %app_name%'
+        notifications:
+            title: 'Notification preferences - %app_name%'

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -1,0 +1,22 @@
+layout:
+    brand: '%app_name%'
+    slogan: "Jeu d'échecs en équipe"
+    console_brand_loaded: "🎯 NeoChess Framework chargé - %app_name%"
+
+auth:
+    login:
+        title: 'Connexion - %app_name%'
+    register:
+        title: 'Créer un compte - %app_name%'
+        hero_tagline: 'Rejoignez la communauté %app_name% et jouez en équipe !'
+
+page:
+    home:
+        title: 'Accueil – %app_name%'
+        hero_title: '🏆 %app_name%'
+        hero_tagline: 'Jouez aux échecs en équipe avec vos amis'
+    user_profile:
+        profile:
+            title: 'Mon Profil - %app_name%'
+        notifications:
+            title: 'Préférences de notifications - %app_name%'


### PR DESCRIPTION
## Summary
- add a translator global for the app name and seed localized brand strings in French and English
- switch the base layout and key templates to translated titles and slogans that reuse the app name placeholder

## Testing
- composer install *(fails: missing ext-sodium extension in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00c8998148327b502a40cdffadfd6