### PR TITLE
Refactor werewolf assignment to use array_find

### DIFF
--- a/src/Application/Service/Werewolf/WerewolfRoleAssigner.php
+++ b/src/Application/Service/Werewolf/WerewolfRoleAssigner.php
@@ -52,24 +52,36 @@ class WerewolfRoleAssigner
             $wolfA = $teamAUsers[$idxA] ?? null;
             $wolfB = $teamBUsers[$idxB] ?? null;
 
-            foreach ($roles as $r) {
-                if ($wolfA && $r->getUser()->getId() === $wolfA->getId() && Game::TEAM_A === $r->getTeamName()) {
-                    $r->setRole('werewolf');
-                }
-                if ($wolfB && $r->getUser()->getId() === $wolfB->getId() && Game::TEAM_B === $r->getTeamName()) {
-                    $r->setRole('werewolf');
-                }
+            $wolfRoleA = array_find(
+                $roles,
+                static fn (GameRole $role): bool => $wolfA
+                    && $role->getUser()->getId() === $wolfA->getId()
+                    && Game::TEAM_A === $role->getTeamName()
+            );
+            if ($wolfRoleA instanceof GameRole) {
+                $wolfRoleA->setRole('werewolf');
+            }
+
+            $wolfRoleB = array_find(
+                $roles,
+                static fn (GameRole $role): bool => $wolfB
+                    && $role->getUser()->getId() === $wolfB->getId()
+                    && Game::TEAM_B === $role->getTeamName()
+            );
+            if ($wolfRoleB instanceof GameRole) {
+                $wolfRoleB->setRole('werewolf');
             }
         } else {
             // single werewolf across all players
             $idx = $this->pickIndex(count($all));
             $wolf = $all[$idx] ?? null;
             if ($wolf) {
-                foreach ($roles as $r) {
-                    if ($r->getUser()->getId() === $wolf->getId()) {
-                        $r->setRole('werewolf');
-                        break;
-                    }
+                $wolfRole = array_find(
+                    $roles,
+                    static fn (GameRole $role): bool => $role->getUser()->getId() === $wolf->getId()
+                );
+                if ($wolfRole instanceof GameRole) {
+                    $wolfRole->setRole('werewolf');
                 }
             }
         }

--- a/tests/Unit/Application/Service/Werewolf/WerewolfRoleAssignerTest.php
+++ b/tests/Unit/Application/Service/Werewolf/WerewolfRoleAssignerTest.php
@@ -40,9 +40,11 @@ final class WerewolfRoleAssignerTest extends KernelTestCase
         $assigner = $c->get(WerewolfRoleAssigner::class);
         $roles = $assigner->assignForGame($g, [$users[0], $users[1]], [$users[2], $users[3]]);
 
-        self::assertNotEmpty($roles);
+        self::assertCount(4, $roles, 'All players should receive a role.');
         $werewolves = array_filter($roles, static fn ($r) => 'werewolf' === $r->getRole());
         self::assertCount(1, $werewolves, 'Should assign exactly one werewolf.');
+        $villagers = array_filter($roles, static fn ($r) => 'villager' === $r->getRole());
+        self::assertCount(3, $villagers, 'All other players should remain villagers.');
     }
 
     public function testAssignTwoWerewolvesWhenOptionEnabled(): void
@@ -79,5 +81,16 @@ final class WerewolfRoleAssignerTest extends KernelTestCase
 
         $wolves = array_filter($roles, static fn ($r) => 'werewolf' === $r->getRole());
         self::assertCount(2, $wolves, 'Should assign one werewolf per team.');
+        $wolvesTeamA = array_filter(
+            $wolves,
+            static fn ($r) => Game::TEAM_A === $r->getTeamName()
+        );
+        $wolvesTeamB = array_filter(
+            $wolves,
+            static fn ($r) => Game::TEAM_B === $r->getTeamName()
+        );
+
+        self::assertCount(1, $wolvesTeamA, 'Team A should have exactly one werewolf.');
+        self::assertCount(1, $wolvesTeamB, 'Team B should have exactly one werewolf.');
     }
 }


### PR DESCRIPTION
## Summary
- replace manual loops in the werewolf role assigner with array_find lookups for the selected wolves
- tighten unit tests to assert villager and per-team werewolf assignments

## Testing
- composer install --ignore-platform-req=ext-sodium
- composer run cs:check
- composer run stan
- ./vendor/bin/phpunit tests/Unit/Application/Service/Werewolf/WerewolfRoleAssignerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e02378bbe48327b39c03d09a2a4c5d