### PR TITLE
Clarify User::eraseCredentials deprecation context

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -115,10 +115,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    #[\Deprecated]
+    #[\Deprecated(message: 'User::eraseCredentials() is deprecated because the entity does not store temporary sensitive data; remove this override once upgrading to Symfony 8 where the method disappears.', since: '2.1.0')]
     public function eraseCredentials(): void
     {
-        // @deprecated, to be removed when upgrading to Symfony 8
+        // @deprecated User::eraseCredentials() kept for Symfony < 8 compatibility; remove when the interface drops it.
     }
 
     /**


### PR DESCRIPTION
## Summary
- provide an explicit deprecation message and version metadata on `User::eraseCredentials()`
- align the inline deprecation comment with the clarified rationale

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e025a603e08327a48f2e11f8d26013