### PR TITLE
Add Hand & Brain metadata to games

### DIFF
--- a/migrations/Version20250919120000.php
+++ b/migrations/Version20250919120000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250919120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Hand & Brain metadata columns to game table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE game ADD hand_brain_current_role VARCHAR(16) DEFAULT NULL');
+        $this->addSql('ALTER TABLE game ADD hand_brain_piece_hint VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE game ADD hand_brain_brain_member_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE game ADD hand_brain_hand_member_id UUID DEFAULT NULL');
+        $this->addSql("COMMENT ON COLUMN game.hand_brain_brain_member_id IS '(DC2Type:uuid)'");
+        $this->addSql("COMMENT ON COLUMN game.hand_brain_hand_member_id IS '(DC2Type:uuid)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE game DROP hand_brain_current_role');
+        $this->addSql('ALTER TABLE game DROP hand_brain_piece_hint');
+        $this->addSql('ALTER TABLE game DROP hand_brain_brain_member_id');
+        $this->addSql('ALTER TABLE game DROP hand_brain_hand_member_id');
+    }
+}

--- a/src/Application/DTO/MakeMoveOutput.php
+++ b/src/Application/DTO/MakeMoveOutput.php
@@ -10,6 +10,10 @@ final class MakeMoveOutput
         public readonly string $turnTeam,
         public readonly int $turnDeadlineTs,
         public readonly string $fen,
+        public readonly ?string $handBrainCurrentRole = null,
+        public readonly ?string $handBrainPieceHint = null,
+        public readonly ?string $handBrainBrainMemberId = null,
+        public readonly ?string $handBrainHandMemberId = null,
     ) {
     }
 }

--- a/src/Application/DTO/ShowGameOutput.php
+++ b/src/Application/DTO/ShowGameOutput.php
@@ -13,6 +13,10 @@ final class ShowGameOutput
         public readonly ?int $turnDeadlineTs,
         public readonly array $teamA, // ['currentIndex'=>int, 'members'=>[...]]
         public readonly array $teamB,
+        public readonly ?string $handBrainCurrentRole = null,
+        public readonly ?string $handBrainPieceHint = null,
+        public readonly ?string $handBrainBrainMemberId = null,
+        public readonly ?string $handBrainHandMemberId = null,
     ) {
     }
 }

--- a/src/Application/DTO/TimeoutTickOutput.php
+++ b/src/Application/DTO/TimeoutTickOutput.php
@@ -11,6 +11,10 @@ final class TimeoutTickOutput
         public readonly string $turnTeam,
         public readonly int $turnDeadlineTs,
         public readonly string $fen,
+        public readonly ?string $handBrainCurrentRole = null,
+        public readonly ?string $handBrainPieceHint = null,
+        public readonly ?string $handBrainBrainMemberId = null,
+        public readonly ?string $handBrainHandMemberId = null,
     ) {
     }
 }

--- a/src/Application/UseCase/MakeMoveHandler.php
+++ b/src/Application/UseCase/MakeMoveHandler.php
@@ -24,7 +24,11 @@ final class MakeMoveHandler
             $result->ply,
             $game->getTurnTeam(),
             $game->getTurnDeadline()?->getTimestamp() * 1000,
-            $game->getFen()
+            $game->getFen(),
+            $game->getHandBrainCurrentRole(),
+            $game->getHandBrainPieceHint(),
+            $game->getHandBrainBrainMemberId(),
+            $game->getHandBrainHandMemberId(),
         );
     }
 }

--- a/src/Application/UseCase/ShowGameHandler.php
+++ b/src/Application/UseCase/ShowGameHandler.php
@@ -55,6 +55,10 @@ class ShowGameHandler
             turnDeadlineTs: $g->getTurnDeadline()?->getTimestamp() * 1000,
             teamA: ['currentIndex' => $ta->getCurrentIndex(), 'members' => $map($listA)],
             teamB: ['currentIndex' => $tb->getCurrentIndex(), 'members' => $map($listB)],
+            handBrainCurrentRole: $g->getHandBrainCurrentRole(),
+            handBrainPieceHint: $g->getHandBrainPieceHint(),
+            handBrainBrainMemberId: $g->getHandBrainBrainMemberId(),
+            handBrainHandMemberId: $g->getHandBrainHandMemberId(),
         );
     }
 }

--- a/src/Application/UseCase/TimeoutTickHandler.php
+++ b/src/Application/UseCase/TimeoutTickHandler.php
@@ -27,7 +27,11 @@ final class TimeoutTickHandler
             $result->ply,
             $game->getTurnTeam(),
             $game->getTurnDeadline()?->getTimestamp() * 1000,
-            $game->getFen()
+            $game->getFen(),
+            $game->getHandBrainCurrentRole(),
+            $game->getHandBrainPieceHint(),
+            $game->getHandBrainBrainMemberId(),
+            $game->getHandBrainHandMemberId(),
         );
     }
 }

--- a/src/Entity/Game.php
+++ b/src/Entity/Game.php
@@ -98,6 +98,19 @@ class Game
     #[ORM\Column(length: 1, nullable: true)]
     private ?string $lastTimeoutTeam = null; // 'A' ou 'B' - pour tracker les timeouts consécutifs
 
+    // Hand & Brain mode metadata
+    #[ORM\Column(length: 16, nullable: true)]
+    private ?string $handBrainCurrentRole = null;
+
+    #[ORM\Column(length: 32, nullable: true)]
+    private ?string $handBrainPieceHint = null;
+
+    #[ORM\Column(type: 'uuid', nullable: true)]
+    private ?string $handBrainBrainMemberId = null;
+
+    #[ORM\Column(type: 'uuid', nullable: true)]
+    private ?string $handBrainHandMemberId = null;
+
     #[ORM\OneToOne(mappedBy: 'game', targetEntity: Invite::class, cascade: ['persist', 'remove'])]
     private ?Invite $invite = null;
 
@@ -425,6 +438,72 @@ class Game
     public function setLastTimeoutTeam(?string $team): self
     {
         $this->lastTimeoutTeam = $team;
+
+        return $this;
+    }
+
+    public function getHandBrainCurrentRole(): ?string
+    {
+        return $this->handBrainCurrentRole;
+    }
+
+    public function setHandBrainCurrentRole(?string $role): self
+    {
+        $this->handBrainCurrentRole = $role;
+
+        return $this;
+    }
+
+    public function getHandBrainPieceHint(): ?string
+    {
+        return $this->handBrainPieceHint;
+    }
+
+    public function setHandBrainPieceHint(?string $hint): self
+    {
+        $this->handBrainPieceHint = $hint;
+
+        return $this;
+    }
+
+    public function getHandBrainBrainMemberId(): ?string
+    {
+        return $this->handBrainBrainMemberId;
+    }
+
+    public function setHandBrainBrainMemberId(?string $memberId): self
+    {
+        $this->handBrainBrainMemberId = $memberId;
+
+        return $this;
+    }
+
+    public function getHandBrainHandMemberId(): ?string
+    {
+        return $this->handBrainHandMemberId;
+    }
+
+    public function setHandBrainHandMemberId(?string $memberId): self
+    {
+        $this->handBrainHandMemberId = $memberId;
+
+        return $this;
+    }
+
+    public function setHandBrainMembers(?string $brainMemberId, ?string $handMemberId): self
+    {
+        $this->handBrainBrainMemberId = $brainMemberId;
+        $this->handBrainHandMemberId = $handMemberId;
+
+        return $this;
+    }
+
+    public function resetHandBrainState(): self
+    {
+        $this->handBrainCurrentRole = null;
+        $this->handBrainPieceHint = null;
+        $this->handBrainBrainMemberId = null;
+        $this->handBrainHandMemberId = null;
 
         return $this;
     }

--- a/tests/Unit/Application/DTO/TimeoutTickOutputTest.php
+++ b/tests/Unit/Application/DTO/TimeoutTickOutputTest.php
@@ -9,12 +9,16 @@ final class TimeoutTickOutputTest extends TestCase
 {
     public function testConstructAndProperties(): void
     {
-        $dto = new TimeoutTickOutput('g1', true, 42, 'B', 999, 'fen-str');
+        $dto = new TimeoutTickOutput('g1', true, 42, 'B', 999, 'fen-str', 'brain', 'knight', 'brain-id', 'hand-id');
         self::assertSame('g1', $dto->gameId);
         self::assertTrue($dto->timedOutApplied);
         self::assertSame(42, $dto->ply);
         self::assertSame('B', $dto->turnTeam);
         self::assertSame(999, $dto->turnDeadlineTs);
         self::assertSame('fen-str', $dto->fen);
+        self::assertSame('brain', $dto->handBrainCurrentRole);
+        self::assertSame('knight', $dto->handBrainPieceHint);
+        self::assertSame('brain-id', $dto->handBrainBrainMemberId);
+        self::assertSame('hand-id', $dto->handBrainHandMemberId);
     }
 }

--- a/tests/Unit/Application/UseCase/MakeMoveHandlerTest.php
+++ b/tests/Unit/Application/UseCase/MakeMoveHandlerTest.php
@@ -32,6 +32,9 @@ final class MakeMoveHandlerTest extends TestCase
             ->setFen('fen-after')
             ->setTurnDeadline(new \DateTimeImmutable('+15 minutes'))
             ->setPly(1)
+            ->setHandBrainCurrentRole('brain')
+            ->setHandBrainPieceHint('knight')
+            ->setHandBrainMembers('member-brain', 'member-hand')
         ;
 
         $result = new MoveResult($game, 42, new \DateTimeImmutable());
@@ -47,5 +50,9 @@ final class MakeMoveHandlerTest extends TestCase
         self::assertSame(Game::TEAM_B, $out->turnTeam);
         self::assertSame('fen-after', $out->fen);
         self::assertSame($game->getTurnDeadline()?->getTimestamp() * 1000, $out->turnDeadlineTs);
+        self::assertSame('brain', $out->handBrainCurrentRole);
+        self::assertSame('knight', $out->handBrainPieceHint);
+        self::assertSame('member-brain', $out->handBrainBrainMemberId);
+        self::assertSame('member-hand', $out->handBrainHandMemberId);
     }
 }

--- a/tests/Unit/Application/UseCase/TimeoutTickHandlerTest.php
+++ b/tests/Unit/Application/UseCase/TimeoutTickHandlerTest.php
@@ -28,6 +28,10 @@ final class TimeoutTickHandlerTest extends TestCase
         $game->method('getFen')->willReturn('fen');
         $deadline = new \DateTimeImmutable('+5 minutes');
         $game->method('getTurnDeadline')->willReturn($deadline);
+        $game->method('getHandBrainCurrentRole')->willReturn('hand');
+        $game->method('getHandBrainPieceHint')->willReturn('pawn');
+        $game->method('getHandBrainBrainMemberId')->willReturn('brain-1');
+        $game->method('getHandBrainHandMemberId')->willReturn('hand-1');
 
         $result = new TimeoutResult($game, 99, true, new \DateTimeImmutable());
 
@@ -47,5 +51,9 @@ final class TimeoutTickHandlerTest extends TestCase
         $this->assertSame('A', $output->turnTeam);
         $this->assertSame($deadline->getTimestamp() * 1000, $output->turnDeadlineTs);
         $this->assertSame('fen', $output->fen);
+        $this->assertSame('hand', $output->handBrainCurrentRole);
+        $this->assertSame('pawn', $output->handBrainPieceHint);
+        $this->assertSame('brain-1', $output->handBrainBrainMemberId);
+        $this->assertSame('hand-1', $output->handBrainHandMemberId);
     }
 }


### PR DESCRIPTION
## Summary
- add nullable Hand & Brain metadata columns on the `game` table and expose them on the `Game` entity
- surface the new fields through game DTOs, handlers, controllers, and the state endpoint so clients can consume them
- cover the new DTO payload with updated unit tests

## Testing
- composer run cs:check
- ./vendor/bin/phpunit *(fails: RegistrationControllerTest::testRegister expects English title text)*

------
https://chatgpt.com/codex/tasks/task_e_68e2acf5fcf08327b13d49b9604e2569